### PR TITLE
Switch results chart to vertical bars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -290,13 +290,13 @@ h1 {
     background-color: rgba(76, 175, 80, 0.3);
 }
 
-@keyframes barGrow {
+@keyframes barGrowVertical {
     from {
-        transform: scaleX(0);
+        transform: scaleY(0);
         opacity: 0;
     }
     to {
-        transform: scaleX(1);
-        opacity: 0.9;
+        transform: scaleY(1);
+        opacity: 0.95;
     }
 }


### PR DESCRIPTION
## Summary
- replace the results visualization with vertically oriented bars and highlight the average size in the chart itself
- drop the vote count and average legend labels so the chart presents only the distribution data
- update the bar animation to scale vertically to match the new layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e432f941e08328be86fd6aefa300b2