### PR TITLE
Add planning poker estimation mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,7 +49,7 @@ TshirtEstimator/
 - **Size**: ~60 lines
 - **Responsibility**: All Firebase-related functionality
 - **Key Functions**:
-  - `createSession()` - Create a new estimation session
+  - `createSession()` - Create a new estimation session (including chosen estimation scale)
   - `getSession()` - Retrieve session data
   - `subscribeToSession()` - Real-time session updates
   - `submitEstimate()` - Submit participant estimates
@@ -62,9 +62,9 @@ TshirtEstimator/
 - **Key Features**:
   - `elements` object - Cached DOM element references
   - `switchToEstimationView()` - View navigation
-  - `updateSessionUI()` - Update UI with session data
+  - `updateSessionUI()` - Update UI with session data and estimation mode configuration
   - `updateParticipantsList()` - Display participant status
-  - `showResults()` - Display estimation results
+  - `showResults()` - Display estimation results with dynamic charts for each estimation mode
 - **Exports**: UI manipulation functions and element references
 
 ### app.js
@@ -73,7 +73,7 @@ TshirtEstimator/
 - **Responsibility**: Application flow and business logic
 - **Key Features**:
   - Event listener setup
-  - Session creation and joining logic
+  - Session creation and joining logic (with estimation type selection)
   - State management (currentSession, currentParticipant)
   - Real-time subscription management
   - Proquint session ID generation (pronounceable, memorable IDs)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A real-time web application for collaborative T-shirt size estimation. Multiple 
 
 - 🎯 **Real-time Collaboration**: Multiple participants can estimate simultaneously
 - 👕 **T-shirt Sizing**: Use standard sizes (XS, S, M, L, XL, XXL) for estimation
+- 🔢 **Planning Poker**: Switch to Fibonacci-based planning poker cards for sprint sizing
 - 🔒 **Hidden Results**: Estimates remain hidden until all participants submit
 - 🔥 **Firebase Integration**: Real-time data synchronization with Firestore
 - 🎨 **Modern UI**: Clean, responsive design using Pico CSS
@@ -52,9 +53,10 @@ A real-time web application for collaborative T-shirt size estimation. Multiple 
 
 1. Enter a task description (e.g., "Implement user authentication")
 2. Enter participant names separated by commas (e.g., "Alice, Bob, Charlie")
-3. Click "Create Session"
-4. Select your name from the prompt
-5. Share the Session ID with other participants (e.g., "lusab-babad" - easy to pronounce and remember!)
+3. Choose an estimation scale (T-shirt sizes or Planning Poker Fibonacci deck)
+4. Click "Create Session"
+5. Select your name from the prompt
+6. Share the Session ID with other participants (e.g., "lusab-babad" - easy to pronounce and remember!)
 
 ### Joining a Session
 
@@ -65,7 +67,7 @@ A real-time web application for collaborative T-shirt size estimation. Multiple 
 
 ### Submitting an Estimate
 
-1. Once in the session, click one of the T-shirt size buttons (XS, S, M, L, XL, XXL)
+1. Once in the session, click one of the estimation buttons (T-shirt sizes or Fibonacci numbers based on the chosen scale)
 2. Your estimate is immediately saved and marked as submitted
 3. Wait for other participants to submit their estimates
 
@@ -113,6 +115,7 @@ sessions/{sessionId}
       - submitted: boolean
   - createdAt: timestamp
   - allSubmitted: boolean
+  - estimationType: 'tshirt' | 'fibonacci'
 ```
 
 ## Security Considerations

--- a/firebase-service.js
+++ b/firebase-service.js
@@ -17,10 +17,11 @@ try {
 }
 
 // Database operations
-export async function createSession(sessionId, taskDescription, participants) {
+export async function createSession(sessionId, taskDescription, participants, estimationType) {
     await setDoc(doc(db, 'sessions', sessionId), {
         taskDescription: taskDescription,
         participants: participants,
+        estimationType: estimationType,
         createdAt: serverTimestamp(),
         allSubmitted: false
     });

--- a/index.html
+++ b/index.html
@@ -27,6 +27,13 @@
                     <input type="text" id="participantNames" name="participantNames" placeholder="Alice, Bob, Charlie"
                            required>
                 </label>
+                <label for="estimationType">
+                    Estimation Scale
+                    <select id="estimationType" name="estimationType">
+                        <option value="tshirt" selected>T-shirt Sizes</option>
+                        <option value="fibonacci">Planning Poker (Fibonacci)</option>
+                    </select>
+                </label>
                 <button type="submit">Create Session</button>
             </form>
         </article>
@@ -63,21 +70,18 @@
             <header>
                 <h3>👋 Welcome, <span id="welcomeParticipantName"></span>!</h3>
             </header>
-            <p>Ready to estimate? Select your T-shirt size below.</p>
+            <p id="welcomeMessage">Ready to estimate? Make your selection below.</p>
         </article>
 
         <article id="yourEstimationSection">
             <header>
                 <h3>Your Estimation</h3>
             </header>
-            <div class="estimation-buttons">
-                <p>Select your T-shirt size estimate:</p>
-                <button class="estimate-btn" data-size="XS">XS</button>
-                <button class="estimate-btn" data-size="S">S</button>
-                <button class="estimate-btn" data-size="M">M</button>
-                <button class="estimate-btn" data-size="L">L</button>
-                <button class="estimate-btn" data-size="XL">XL</button>
-                <button class="estimate-btn" data-size="XXL">XXL</button>
+            <div class="estimation-panel">
+                <p id="estimationPrompt" class="estimation-prompt">Select your T-shirt size estimate:</p>
+                <div id="estimationButtons" class="estimation-buttons">
+                    <!-- Estimation buttons will be injected here -->
+                </div>
             </div>
             <footer id="yourEstimateDisplay" class="hidden">
                 <p>You estimated: <strong id="yourEstimate"></strong></p>
@@ -108,7 +112,7 @@
 
             <!-- Average Size Visualization -->
             <div id="averageSizeSection" class="average-size-section">
-                <h4>Average Estimate: <span id="averageSize"></span></h4>
+                <h4 id="averageEstimateHeading"><span id="averageEstimateLabel">Average Estimate</span>: <span id="averageSize"></span></h4>
                 <svg id="sizesVisualization" class="sizes-svg" viewBox="0 0 700 400" xmlns="http://www.w3.org/2000/svg">
                     <!-- Size distribution bars will be dynamically added here -->
                 </svg>

--- a/styles.css
+++ b/styles.css
@@ -33,11 +33,23 @@ h2, h3 {
     }
 }
 
+
+.estimation-panel {
+    display: flex;
+    flex-direction: column;
+    margin: 1rem 0;
+    gap: 0.5rem;
+}
+
+.estimation-prompt {
+    font-weight: 600;
+    margin: 0;
+}
+
 .estimation-buttons {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
     gap: 0.5rem;
-    margin: 1rem 0;
 }
 
 .estimation-buttons button {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -62,6 +62,7 @@ beforeEach(() => {
     <form id="createSessionForm"></form>
     <input id="taskDescription" value="Build feature X" />
     <input id="participantNames" value="Alice, Bob" />
+    <select id="estimationType"><option value="tshirt" selected>T-shirt</option></select>
     <form id="joinSessionForm"></form>
     <input id="sessionId" value="abcde-fghij" />
     <button id="backButton"></button>
@@ -73,7 +74,10 @@ beforeEach(() => {
     <div id="resultsGrid"></div>
     <div id="waitingSection" class="hidden"></div>
     <div id="yourEstimationSection">
-      <div class="estimation-buttons"></div>
+      <div class="estimation-panel">
+        <p id="estimationPrompt" class="estimation-prompt"></p>
+        <div id="estimationButtons" class="estimation-buttons"></div>
+      </div>
     </div>
     <div id="yourEstimateDisplay" class="hidden"></div>
     <div id="yourEstimate"></div>

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -19,7 +19,10 @@ describe('DOM Manipulation Tests', () => {
         <div id="resultsGrid"></div>
         <div id="waitingSection" class="hidden"></div>
         <div id="yourEstimationSection">
-          <div class="estimation-buttons"></div>
+          <div class="estimation-panel">
+            <p id="estimationPrompt" class="estimation-prompt"></p>
+            <div id="estimationButtons" class="estimation-buttons"></div>
+          </div>
         </div>
         <div id="yourEstimateDisplay" class="hidden"></div>
         <div id="yourEstimate"></div>

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -13,14 +13,19 @@ describe('UI Module Tests', () => {
       <h2 id="taskTitle"></h2>
       <div id="currentSessionId"></div>
       <div id="currentParticipantName"></div>
-      <div id="welcomeBanner" class="hidden"></div>
+      <div id="welcomeBanner" class="hidden"><p id="welcomeMessage"></p></div>
       <span id="welcomeParticipantName"></span>
       <div id="participantsList"></div>
-      <div id="resultsSection" class="hidden"></div>
+      <div id="resultsSection" class="hidden">
+        <h4 id="averageEstimateHeading"><span id="averageEstimateLabel">Average Estimate</span>: <span id="averageSize"></span></h4>
+      </div>
       <div id="resultsGrid"></div>
       <div id="waitingSection" class="hidden"></div>
       <div id="yourEstimationSection">
-        <div class="estimation-buttons"></div>
+        <div class="estimation-panel">
+          <p id="estimationPrompt" class="estimation-prompt"></p>
+          <div id="estimationButtons" class="estimation-buttons"></div>
+        </div>
       </div>
       <div id="yourEstimateDisplay" class="hidden"></div>
       <div id="yourEstimate"></div>
@@ -96,6 +101,7 @@ describe('UI Module Tests', () => {
 
   describe('updateSessionUI', () => {
     const mockSessionData = {
+      estimationType: 'tshirt',
       taskDescription: 'Implement feature X',
       participants: {
         'Alice': { name: 'Alice', estimate: 'M', submitted: true },
@@ -104,10 +110,38 @@ describe('UI Module Tests', () => {
       }
     };
 
+    const fibonacciSessionData = {
+      estimationType: 'fibonacci',
+      taskDescription: 'Estimate API work',
+      participants: {
+        'Alice': { name: 'Alice', estimate: '3', submitted: true },
+        'Bob': { name: 'Bob', estimate: '5', submitted: true }
+      }
+    };
+
     it('should update task title', () => {
       updateSessionUI(mockSessionData, 'Alice');
 
       expect(elements.taskTitle.textContent).toBe('Task: Implement feature X');
+    });
+
+    it('should render estimation buttons for the configured mode', () => {
+      updateSessionUI(mockSessionData, 'Bob');
+
+      const buttons = elements.yourEstimationSection.querySelectorAll('.estimate-btn');
+      expect(buttons.length).toBe(6);
+      expect(Array.from(buttons).map(btn => btn.textContent)).toEqual(['XS', 'S', 'M', 'L', 'XL', 'XXL']);
+    });
+
+    it('should configure planning poker sessions with Fibonacci prompt', () => {
+      updateSessionUI(fibonacciSessionData, 'Alice');
+
+      expect(elements.estimationPrompt.textContent).toBe('Select your Fibonacci estimate:');
+      expect(elements.averageEstimateLabel.textContent).toBe('Average Estimate (Planning Poker)');
+      expect(document.getElementById('averageSize').textContent).toBe('4.0 (≈3)');
+      const fibButtons = elements.yourEstimationSection.querySelectorAll('.estimate-btn');
+      expect(fibButtons.length).toBe(10);
+      expect(Array.from(fibButtons).map(btn => btn.textContent)).toEqual(['1', '2', '3', '5', '8', '13', '21', '34', '55', '89']);
     });
 
     it('should update participants list', () => {
@@ -135,7 +169,7 @@ describe('UI Module Tests', () => {
       updateSessionUI(mockSessionData, 'Bob');
 
       const estimationButtons = elements.yourEstimationSection.querySelector('.estimation-buttons');
-      expect(estimationButtons.style.display).not.toBe('none');
+      expect(estimationButtons.style.display).toBe('grid');
     });
 
     it('should show results when all participants have submitted', () => {

--- a/ui.js
+++ b/ui.js
@@ -16,7 +16,48 @@ export const elements = {
     get yourEstimateDisplay() { return document.getElementById('yourEstimateDisplay'); },
     get yourEstimate() { return document.getElementById('yourEstimate'); },
     get welcomeBanner() { return document.getElementById('welcomeBanner'); },
-    get welcomeParticipantName() { return document.getElementById('welcomeParticipantName'); }
+    get welcomeParticipantName() { return document.getElementById('welcomeParticipantName'); },
+    get estimationPrompt() { return document.getElementById('estimationPrompt'); },
+    get estimationButtons() { return document.getElementById('estimationButtons'); },
+    get averageEstimateLabel() { return document.getElementById('averageEstimateLabel'); },
+    get welcomeMessage() { return document.getElementById('welcomeMessage'); }
+};
+
+const ESTIMATION_MODES = {
+    tshirt: {
+        id: 'tshirt',
+        label: 'T-shirt Sizes',
+        shortLabel: 'T-shirt',
+        prompt: 'Select your T-shirt size estimate:',
+        welcomeMessage: 'Ready to estimate? Select your T-shirt size below.',
+        options: [
+            { value: 'XS', label: 'XS', numeric: 1 },
+            { value: 'S', label: 'S', numeric: 2 },
+            { value: 'M', label: 'M', numeric: 3 },
+            { value: 'L', label: 'L', numeric: 4 },
+            { value: 'XL', label: 'XL', numeric: 5 },
+            { value: 'XXL', label: 'XXL', numeric: 6 }
+        ]
+    },
+    fibonacci: {
+        id: 'fibonacci',
+        label: 'Planning Poker (Fibonacci)',
+        shortLabel: 'Planning Poker',
+        prompt: 'Select your Fibonacci estimate:',
+        welcomeMessage: 'Ready to estimate? Choose your Fibonacci number below.',
+        options: [
+            { value: '1', label: '1', numeric: 1 },
+            { value: '2', label: '2', numeric: 2 },
+            { value: '3', label: '3', numeric: 3 },
+            { value: '5', label: '5', numeric: 5 },
+            { value: '8', label: '8', numeric: 8 },
+            { value: '13', label: '13', numeric: 13 },
+            { value: '21', label: '21', numeric: 21 },
+            { value: '34', label: '34', numeric: 34 },
+            { value: '55', label: '55', numeric: 55 },
+            { value: '89', label: '89', numeric: 89 }
+        ]
+    }
 };
 
 // UI update functions
@@ -40,21 +81,25 @@ export function switchToSetupView() {
 }
 
 export function updateSessionUI(sessionData, currentParticipant) {
+    const config = getEstimationConfig(sessionData);
+
+    configureEstimationExperience(config);
+
     elements.taskTitle.textContent = `Task: ${sessionData.taskDescription}`;
     elements.currentParticipantName.textContent = currentParticipant || 'Viewing Results';
 
     // Update participants list
     updateParticipantsList(sessionData.participants);
-    
+
     // Check if current participant has submitted
-    const currentParticipantData = sessionData.participants[currentParticipant];
+    const currentParticipantData = currentParticipant ? sessionData.participants[currentParticipant] : undefined;
     updateEstimationSection(currentParticipantData);
-    
+
     // Check if all submitted
     const allSubmitted = Object.values(sessionData.participants).every(p => p.submitted);
-    
+
     if (allSubmitted) {
-        showResults(sessionData.participants);
+        showResults(sessionData, config);
     } else if (currentParticipantData && currentParticipantData.submitted) {
         showWaitingMessage();
     } else {
@@ -69,205 +114,50 @@ export function updateSessionUI(sessionData, currentParticipant) {
         if (elements.welcomeBanner) {
             elements.welcomeBanner.classList.remove('hidden');
         }
-    } else {
-        if (elements.welcomeBanner) {
-            elements.welcomeBanner.classList.add('hidden');
-        }
+    } else if (elements.welcomeBanner) {
+        elements.welcomeBanner.classList.add('hidden');
     }
 }
 
-// T-shirt size utilities
-const SIZE_VALUES = {
-    'XS': 1,
-    'S': 2,
-    'M': 3,
-    'L': 4,
-    'XL': 5,
-    'XXL': 6
-};
-
-const SIZE_NAMES = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
-
-function calculateAverageSize(participants) {
-    const estimates = Object.values(participants)
-        .filter(p => p.estimate && p.submitted)
-        .map(p => SIZE_VALUES[p.estimate]);
-
-    if (estimates.length === 0) return null;
-
-    const sum = estimates.reduce((acc, val) => acc + val, 0);
-    return sum / estimates.length;
+function getEstimationConfig(sessionData) {
+    const type = sessionData?.estimationType;
+    return ESTIMATION_MODES[type] || ESTIMATION_MODES.tshirt;
 }
 
-function getAverageSizeName(averageValue) {
-    if (averageValue === null) return 'N/A';
-
-    // Round to nearest size
-    const roundedIndex = Math.round(averageValue) - 1;
-    const clampedIndex = Math.max(0, Math.min(SIZE_NAMES.length - 1, roundedIndex));
-
-    return SIZE_NAMES[clampedIndex];
+function configureEstimationExperience(config) {
+    if (elements.estimationPrompt) {
+        elements.estimationPrompt.textContent = config.prompt;
+    }
+    if (elements.welcomeMessage) {
+        elements.welcomeMessage.textContent = config.welcomeMessage;
+    }
+    renderEstimationButtons(config);
 }
 
-function getSizeDistribution(participants) {
-    const distribution = {
-        'XS': 0, 'S': 0, 'M': 0, 'L': 0, 'XL': 0, 'XXL': 0
-    };
+function renderEstimationButtons(config) {
+    const container = elements.estimationButtons;
+    if (!container) {
+        return;
+    }
 
-    Object.values(participants)
-        .filter(p => p.estimate && p.submitted)
-        .forEach(p => {
-            if (distribution.hasOwnProperty(p.estimate)) {
-                distribution[p.estimate]++;
-            }
-        });
+    const shouldSkipRender = container.dataset.mode === config.id
+        && container.childElementCount === config.options.length;
 
-    return distribution;
-}
+    if (shouldSkipRender) {
+        return;
+    }
 
-function createSizeVisualization(participants, averageValue) {
-    const svg = document.getElementById('sizesVisualization');
-    const legend = document.getElementById('sizeLegend');
+    container.innerHTML = '';
+    container.dataset.mode = config.id;
 
-    if (!svg || !legend) return;
-
-    // Clear previous content
-    svg.innerHTML = '';
-    legend.innerHTML = '';
-    legend.classList.add('hidden');
-
-    const distribution = getSizeDistribution(participants);
-    const totalParticipants = Object.values(distribution).reduce((a, b) => a + b, 0);
-
-    if (totalParticipants === 0) return;
-
-    // Add gradient definitions
-    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
-    defs.innerHTML = `
-        <linearGradient id="barGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-            <stop offset="0%" style="stop-color:#2196f3;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#1976d2;stop-opacity:1" />
-        </linearGradient>
-        <linearGradient id="barGradientAverage" x1="0%" y1="100%" x2="0%" y2="0%">
-            <stop offset="0%" style="stop-color:#ffa726;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#ff9800;stop-opacity:1" />
-        </linearGradient>
-    `;
-    svg.appendChild(defs);
-
-    // Configuration for vertical layout
-    const width = 700;
-    const height = 400;
-    const margin = { top: 30, right: 40, bottom: 80, left: 40 };
-    const chartWidth = width - margin.left - margin.right;
-    const chartHeight = height - margin.top - margin.bottom;
-
-    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
-
-    const chartGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    chartGroup.setAttribute('transform', `translate(${margin.left}, ${margin.top})`);
-    svg.appendChild(chartGroup);
-
-    const baseline = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-    baseline.setAttribute('x1', '0');
-    baseline.setAttribute('y1', chartHeight);
-    baseline.setAttribute('x2', chartWidth);
-    baseline.setAttribute('y2', chartHeight);
-    baseline.setAttribute('stroke', 'rgba(255, 255, 255, 0.2)');
-    baseline.setAttribute('stroke-width', '2');
-    chartGroup.appendChild(baseline);
-
-    const maxCount = Math.max(...Object.values(distribution));
-    const sectionWidth = chartWidth / SIZE_NAMES.length;
-    const barWidth = Math.min(60, sectionWidth * 0.6);
-
-    SIZE_NAMES.forEach((size, index) => {
-        const count = distribution[size];
-        const sizeValue = SIZE_VALUES[size];
-        const isAverage = Math.round(averageValue) === sizeValue;
-
-        const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0;
-        const x = index * sectionWidth + (sectionWidth - barWidth) / 2;
-        const y = chartHeight - barHeight;
-
-        const bgBar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-        bgBar.setAttribute('x', index * sectionWidth + (sectionWidth - barWidth) / 2);
-        bgBar.setAttribute('y', 0);
-        bgBar.setAttribute('width', barWidth);
-        bgBar.setAttribute('height', chartHeight);
-        bgBar.setAttribute('fill', 'rgba(128, 128, 128, 0.1)');
-        bgBar.setAttribute('rx', '6');
-        chartGroup.appendChild(bgBar);
-
-        if (count > 0) {
-            const bar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-            bar.setAttribute('x', x);
-            bar.setAttribute('y', y);
-            bar.setAttribute('width', barWidth);
-            bar.setAttribute('height', barHeight);
-            bar.setAttribute('fill', isAverage ? 'url(#barGradientAverage)' : 'url(#barGradient)');
-            bar.setAttribute('rx', '6');
-            bar.setAttribute('opacity', '0.95');
-            bar.style.animation = 'barGrowVertical 0.6s ease-out';
-            bar.style.transformOrigin = 'center bottom';
-            chartGroup.appendChild(bar);
-
-            const countLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-            countLabel.setAttribute('x', x + barWidth / 2);
-            countLabel.setAttribute('y', y - 10);
-            countLabel.setAttribute('text-anchor', 'middle');
-            countLabel.setAttribute('fill', 'currentColor');
-            countLabel.setAttribute('font-size', '16');
-            countLabel.setAttribute('font-weight', 'bold');
-            countLabel.textContent = count;
-            chartGroup.appendChild(countLabel);
-        }
-
-        const sizeLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        sizeLabel.setAttribute('x', index * sectionWidth + sectionWidth / 2);
-        sizeLabel.setAttribute('y', chartHeight + 30);
-        sizeLabel.setAttribute('text-anchor', 'middle');
-        sizeLabel.setAttribute('fill', 'currentColor');
-        sizeLabel.setAttribute('font-size', isAverage ? '20' : '16');
-        sizeLabel.setAttribute('font-weight', isAverage ? 'bold' : '600');
-        sizeLabel.textContent = size;
-        chartGroup.appendChild(sizeLabel);
-
-        if (isAverage) {
-            const star = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-            star.setAttribute('x', index * sectionWidth + sectionWidth / 2);
-            star.setAttribute('y', Math.max(y - 25, 0) + 10);
-            star.setAttribute('text-anchor', 'middle');
-            star.setAttribute('fill', '#ffa726');
-            star.setAttribute('font-size', '28');
-            star.textContent = '⭐';
-            chartGroup.appendChild(star);
-        }
+    config.options.forEach(option => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.classList.add('estimate-btn');
+        button.setAttribute('data-size', option.value);
+        button.textContent = option.label;
+        container.appendChild(button);
     });
-
-    legend.innerHTML = '';
-}
-
-function showResults(participants) {
-    elements.resultsSection.classList.remove('hidden');
-    elements.waitingSection.classList.add('hidden');
-
-    // Calculate and display average size
-    const averageValue = calculateAverageSize(participants);
-    const averageSizeName = getAverageSizeName(averageValue);
-
-    const averageSizeElement = document.getElementById('averageSize');
-    if (averageSizeElement) {
-        averageSizeElement.textContent = averageSizeName;
-        if (averageValue !== null) {
-            averageSizeElement.textContent += ` (${averageValue.toFixed(2)})`;
-        }
-    }
-
-    // Create visualization
-    if (averageValue !== null) {
-        createSizeVisualization(participants, averageValue);
-    }
 }
 
 function updateParticipantsList(participants) {
@@ -307,21 +197,261 @@ function updateParticipantsList(participants) {
 }
 
 function updateEstimationSection(currentParticipantData) {
-    const estimationButtons = elements.yourEstimationSection.querySelector('.estimation-buttons');
+    const estimationSection = elements.yourEstimationSection;
+    if (!estimationSection) {
+        return;
+    }
+
+    const estimationPanel = estimationSection.querySelector('.estimation-panel');
+    const estimationButtons = elements.estimationButtons;
 
     if (!currentParticipantData) {
-        // Hide estimation section if no participant selected
-        elements.yourEstimationSection.style.display = 'none';
-    } else if (currentParticipantData.submitted) {
-        elements.yourEstimationSection.style.display = 'block';
-        estimationButtons.style.display = 'none';
+        estimationSection.style.display = 'none';
+        if (estimationPanel) {
+            estimationPanel.style.display = '';
+        }
+        if (estimationButtons) {
+            estimationButtons.style.display = 'grid';
+        }
+        elements.yourEstimateDisplay.classList.add('hidden');
+        return;
+    }
+
+    estimationSection.style.display = 'block';
+
+    if (currentParticipantData.submitted) {
+        if (estimationPanel) {
+            estimationPanel.style.display = 'none';
+        }
+        if (estimationButtons) {
+            estimationButtons.style.display = 'none';
+        }
         elements.yourEstimateDisplay.classList.remove('hidden');
-        elements.yourEstimate.textContent = currentParticipantData.estimate;
+        if (elements.yourEstimate) {
+            elements.yourEstimate.textContent = currentParticipantData.estimate;
+        }
     } else {
-        elements.yourEstimationSection.style.display = 'block';
-        estimationButtons.style.display = 'grid';
+        if (estimationPanel) {
+            estimationPanel.style.display = '';
+        }
+        if (estimationButtons) {
+            estimationButtons.style.display = 'grid';
+        }
         elements.yourEstimateDisplay.classList.add('hidden');
     }
+}
+
+function calculateAverage(participants, config) {
+    const numericEstimates = Object.values(participants)
+        .filter(participant => participant.submitted && participant.estimate !== null && participant.estimate !== undefined)
+        .map(participant => getNumericValue(config, participant.estimate))
+        .filter(value => typeof value === 'number' && !Number.isNaN(value));
+
+    if (numericEstimates.length === 0) {
+        return null;
+    }
+
+    const total = numericEstimates.reduce((sum, value) => sum + value, 0);
+    return total / numericEstimates.length;
+}
+
+function getNumericValue(config, value) {
+    const option = config.options.find(opt => opt.value === value);
+    return typeof option?.numeric === 'number' ? option.numeric : null;
+}
+
+function getNearestOption(config, averageValue) {
+    if (averageValue === null) {
+        return null;
+    }
+
+    let nearestOption = null;
+    let smallestDifference = Infinity;
+
+    config.options.forEach(option => {
+        if (typeof option.numeric !== 'number') {
+            return;
+        }
+
+        const difference = Math.abs(option.numeric - averageValue);
+        if (difference < smallestDifference) {
+            smallestDifference = difference;
+            nearestOption = option;
+        }
+    });
+
+    return nearestOption;
+}
+
+function formatAverageDisplay(config, averageValue, nearestOption) {
+    if (averageValue === null) {
+        return 'N/A';
+    }
+
+    const numericText = Number.isFinite(averageValue) ? averageValue.toFixed(config.id === 'fibonacci' ? 1 : 2) : `${averageValue}`;
+
+    if (config.id === 'tshirt') {
+        return nearestOption ? `${nearestOption.label} (${numericText})` : numericText;
+    }
+
+    if (config.id === 'fibonacci') {
+        const approx = nearestOption ? ` (≈${nearestOption.label})` : '';
+        return `${numericText}${approx}`;
+    }
+
+    return nearestOption ? `${numericText} (${nearestOption.label})` : numericText;
+}
+
+function createEstimationVisualization(participants, config, averageValue, nearestOption) {
+    const svg = document.getElementById('sizesVisualization');
+    const legend = document.getElementById('sizeLegend');
+
+    if (!svg || !legend) {
+        return;
+    }
+
+    svg.innerHTML = '';
+    legend.innerHTML = '';
+    legend.classList.add('hidden');
+
+    const distribution = config.options.reduce((acc, option) => {
+        acc[option.value] = 0;
+        return acc;
+    }, {});
+
+    Object.values(participants)
+        .filter(participant => participant.submitted && distribution.hasOwnProperty(participant.estimate))
+        .forEach(participant => {
+            distribution[participant.estimate]++;
+        });
+
+    const totalParticipants = Object.values(distribution).reduce((sum, value) => sum + value, 0);
+
+    if (totalParticipants === 0) {
+        return;
+    }
+
+    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+    defs.innerHTML = `
+        <linearGradient id="barGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+            <stop offset="0%" style="stop-color:#2196f3;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#1976d2;stop-opacity:1" />
+        </linearGradient>
+        <linearGradient id="barGradientAverage" x1="0%" y1="100%" x2="0%" y2="0%">
+            <stop offset="0%" style="stop-color:#ffa726;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#ff9800;stop-opacity:1" />
+        </linearGradient>
+    `;
+    svg.appendChild(defs);
+
+    const width = 700;
+    const height = 400;
+    const margin = { top: 30, right: 40, bottom: 80, left: 40 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+    const chartGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    chartGroup.setAttribute('transform', `translate(${margin.left}, ${margin.top})`);
+    svg.appendChild(chartGroup);
+
+    const baseline = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    baseline.setAttribute('x1', '0');
+    baseline.setAttribute('y1', chartHeight);
+    baseline.setAttribute('x2', chartWidth);
+    baseline.setAttribute('y2', chartHeight);
+    baseline.setAttribute('stroke', 'rgba(255, 255, 255, 0.2)');
+    baseline.setAttribute('stroke-width', '2');
+    chartGroup.appendChild(baseline);
+
+    const maxCount = Math.max(...Object.values(distribution));
+    const sectionWidth = chartWidth / config.options.length;
+    const barWidth = Math.min(60, sectionWidth * 0.6);
+    const highlightValue = nearestOption?.value ?? null;
+
+    config.options.forEach((option, index) => {
+        const count = distribution[option.value];
+        const isAverage = highlightValue === option.value;
+
+        const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0;
+        const x = index * sectionWidth + (sectionWidth - barWidth) / 2;
+        const y = chartHeight - barHeight;
+
+        const bgBar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        bgBar.setAttribute('x', index * sectionWidth + (sectionWidth - barWidth) / 2);
+        bgBar.setAttribute('y', 0);
+        bgBar.setAttribute('width', barWidth);
+        bgBar.setAttribute('height', chartHeight);
+        bgBar.setAttribute('fill', 'rgba(128, 128, 128, 0.1)');
+        bgBar.setAttribute('rx', '6');
+        chartGroup.appendChild(bgBar);
+
+        if (count > 0) {
+            const bar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            bar.setAttribute('x', x);
+            bar.setAttribute('y', y);
+            bar.setAttribute('width', barWidth);
+            bar.setAttribute('height', barHeight);
+            bar.setAttribute('fill', isAverage ? 'url(#barGradientAverage)' : 'url(#barGradient)');
+            bar.setAttribute('rx', '6');
+            bar.setAttribute('opacity', '0.95');
+            bar.style.animation = 'barGrowVertical 0.6s ease-out';
+            bar.style.transformOrigin = 'center bottom';
+            chartGroup.appendChild(bar);
+
+            const countLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            countLabel.setAttribute('x', x + barWidth / 2);
+            countLabel.setAttribute('y', y - 10);
+            countLabel.setAttribute('text-anchor', 'middle');
+            countLabel.setAttribute('fill', 'currentColor');
+            countLabel.setAttribute('font-size', '16');
+            countLabel.setAttribute('font-weight', 'bold');
+            countLabel.textContent = count;
+            chartGroup.appendChild(countLabel);
+        }
+
+        const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        label.setAttribute('x', index * sectionWidth + sectionWidth / 2);
+        label.setAttribute('y', chartHeight + 30);
+        label.setAttribute('text-anchor', 'middle');
+        label.setAttribute('fill', 'currentColor');
+        label.setAttribute('font-size', isAverage ? '20' : '16');
+        label.setAttribute('font-weight', isAverage ? 'bold' : '600');
+        label.textContent = option.label;
+        chartGroup.appendChild(label);
+
+        if (isAverage && averageValue !== null) {
+            const star = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            star.setAttribute('x', index * sectionWidth + sectionWidth / 2);
+            star.setAttribute('y', Math.max(y - 25, 0) + 10);
+            star.setAttribute('text-anchor', 'middle');
+            star.setAttribute('fill', '#ffa726');
+            star.setAttribute('font-size', '28');
+            star.textContent = '⭐';
+            chartGroup.appendChild(star);
+        }
+    });
+}
+
+function showResults(sessionData, config) {
+    elements.resultsSection.classList.remove('hidden');
+    elements.waitingSection.classList.add('hidden');
+
+    if (elements.averageEstimateLabel) {
+        const labelSuffix = config.shortLabel || config.label;
+        elements.averageEstimateLabel.textContent = `Average Estimate (${labelSuffix})`;
+    }
+
+    const averageValue = calculateAverage(sessionData.participants, config);
+    const nearestOption = getNearestOption(config, averageValue);
+
+    const averageSizeElement = document.getElementById('averageSize');
+    if (averageSizeElement) {
+        averageSizeElement.textContent = formatAverageDisplay(config, averageValue, nearestOption);
+    }
+
+    createEstimationVisualization(sessionData.participants, config, averageValue, nearestOption);
 }
 
 function showWaitingMessage() {


### PR DESCRIPTION
## Summary
- add an estimation scale picker to session creation so teams can use T-shirt sizes or Fibonacci planning poker
- render estimation controls, averages, and charts dynamically per mode while persisting the selected scale in session data
- refresh documentation and automated tests to cover the new planning poker workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4d6e706fc8328941e6d06ee414955